### PR TITLE
Annotations 2.0: Read annotations from functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
     "autoload-dev": {
         "psr-4": {
             "Doctrine\\AnnotationsTests\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/Fixtures/functions.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/src/Annotation/Target.php
+++ b/src/Annotation/Target.php
@@ -36,7 +36,8 @@ final class Target
     const TARGET_METHOD             = 2;
     const TARGET_PROPERTY           = 4;
     const TARGET_ANNOTATION         = 8;
-    const TARGET_ALL                = 15;
+    const TARGET_FUNCTION           = 16;
+    const TARGET_ALL                = 31;
 
     /**
      * @var array
@@ -46,6 +47,7 @@ final class Target
         'CLASS'      => self::TARGET_CLASS,
         'METHOD'     => self::TARGET_METHOD,
         'PROPERTY'   => self::TARGET_PROPERTY,
+        'FUNCTION'   => self::TARGET_FUNCTION,
         'ANNOTATION' => self::TARGET_ANNOTATION,
     );
 
@@ -122,6 +124,10 @@ final class Target
 
         if ($target & self::TARGET_PROPERTY) {
             $names[] = 'PROPERTY';
+        }
+
+        if ($target & self::TARGET_FUNCTION) {
+            $names[] = 'FUNCTION';
         }
 
         if ($target & self::TARGET_ANNOTATION) {

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -40,7 +40,7 @@ use Doctrine\Annotations\Annotation\IgnoreAnnotation;
  * @author Fabio B. Silva <fabio.bat.silva@hotmail.com>
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  */
-final class AnnotationReader implements Reader, FunctionReader
+final class AnnotationReader implements Reader
 {
     /**
      * @var \Doctrine\Annotations\Parser\PhpParser

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Doctrine\Annotations;
 
 use ReflectionClass;
+use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -39,7 +40,7 @@ use Doctrine\Annotations\Annotation\IgnoreAnnotation;
  * @author Fabio B. Silva <fabio.bat.silva@hotmail.com>
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  */
-final class AnnotationReader implements Reader
+final class AnnotationReader implements Reader, FunctionReader
 {
     /**
      * @var \Doctrine\Annotations\Parser\PhpParser
@@ -199,16 +200,52 @@ final class AnnotationReader implements Reader
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getFunctionAnnotations(ReflectionFunction $function) : array
+    {
+        if (($docblock = $function->getDocComment()) === false) {
+            return [];
+        }
+
+        $functionName = $function->getName();
+        $namespace    = $function->getNamespaceName();
+        $reflection   = $this->reflectionFactory->getReflectionFunction($functionName);
+
+        $imports = $reflection->getImports();
+        $ignored = $this->getIgnoredAnnotationNames($function);
+        $context = new Context($function, [$namespace], $imports, $ignored);
+
+        return $this->docParser->parse($docblock, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFunctionAnnotation(ReflectionFunction $function, string $annotationName)
+    {
+        $annotations = $this->getFunctionAnnotations($function);
+
+        foreach ($annotations as $annotation) {
+            if ($annotation instanceof $annotationName) {
+                return $annotation;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Returns the ignored annotations for the given class.
      *
-     * @param \ReflectionClass $class
+     * @param \ReflectionClass|\ReflectionFunction $reflection
      *
      * @return array
      */
-    private function getIgnoredAnnotationNames(ReflectionClass $class) : array
+    private function getIgnoredAnnotationNames($reflection) : array
     {
         $ignoredNames = $this->ignoredAnnotationNames->getArrayCopy();
-        $annotations  = $this->metadataParser->parseAnnotationClass($class);
+        $annotations  = $this->metadataParser->parseAnnotation($reflection);
 
         foreach ($annotations as $annotation) {
             if ( ! $annotation instanceof IgnoreAnnotation) {

--- a/src/CachedReader.php
+++ b/src/CachedReader.php
@@ -36,7 +36,7 @@ use Doctrine\Common\Cache\Cache;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Fabio B. Silva <fabio.bat.silva@hotmail.com>
  */
-final class CachedReader implements Reader, FunctionReader
+final class CachedReader implements Reader
 {
     /**
      * @var string
@@ -44,7 +44,7 @@ final class CachedReader implements Reader, FunctionReader
     const CACHE_SALT = '@[Annot]';
 
     /**
-     * @var \Doctrine\Annotations\Reader|\Doctrine\Annotations\FunctionReader
+     * @var \Doctrine\Annotations\Reader
      */
     private $delegate;
 
@@ -61,21 +61,12 @@ final class CachedReader implements Reader, FunctionReader
     /**
      * Constructor.
      *
-     * @param \Doctrine\Annotations\ObjectReader|\Doctrine\Annotations\FunctionReader $reader
-     * @param \Doctrine\Common\Cache\Cache                                            $cache
-     * @param bool                                                                    $debug
+     * @param \Doctrine\Annotations\Reader $reader
+     * @param \Doctrine\Common\Cache\Cache $cache
+     * @param bool                         $debug
      */
-    public function __construct($reader, Cache $cache, bool $debug = false)
+    public function __construct(Reader $reader, Cache $cache, bool $debug = false)
     {
-        if ( ! $reader instanceof ObjectReader && ! $reader instanceof FunctionReader) {
-            throw new \InvalidArgumentException(sprintf(
-                'Delegated reader must be an instance of %s or %s, got %s',
-                ObjectReader::class,
-                FunctionReader::class,
-                get_class($reader)
-            ));
-        }
-
         $this->delegate = $reader;
         $this->cache    = $cache;
         $this->debug    = $debug;

--- a/src/Context.php
+++ b/src/Context.php
@@ -23,6 +23,7 @@ namespace Doctrine\Annotations;
 
 use Reflector;
 use ReflectionClass;
+use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionProperty;
 use Doctrine\Annotations\Annotation\Target;
@@ -106,7 +107,7 @@ class Context
     /**
      * @param string $name
      *
-     * @return array
+     * @return bool
      */
     public function isIgnoredName($name) : bool
     {
@@ -154,6 +155,10 @@ class Context
             return Target::TARGET_PROPERTY;
         }
 
+        if ($this->reflection instanceof ReflectionFunction) {
+            return Target::TARGET_FUNCTION;
+        }
+
         throw new \RuntimeException('Unsupported target : ' . get_class($this->reflection));
     }
 
@@ -181,6 +186,13 @@ class Context
             $name    = $this->reflection->getName();
             $class   = $this->reflection->getDeclaringClass();
             $context = 'property ' . $class->getName() . '::$' . $name;
+
+            return $context;
+        }
+
+        if ($this->reflection instanceof ReflectionFunction) {
+            $name    = $this->reflection->getName();
+            $context = 'function ' . $name;
 
             return $context;
         }

--- a/src/FunctionReader.php
+++ b/src/FunctionReader.php
@@ -19,49 +19,37 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Annotations\Reflection;
+namespace Doctrine\Annotations;
 
-use Doctrine\Annotations\Parser\PhpParser;
+use ReflectionFunction;
 
 /**
- * Reflection Class
+ * Interface for function annotation readers.
  *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
-class ReflectionClass extends \ReflectionClass
+interface FunctionReader
 {
     /**
-     * @var \Doctrine\Annotations\Parser\PhpParser
-     */
-    private $phpParser;
-
-    /**
-     * @var array
-     */
-    private $imports;
-
-    /**
-     * Constructor.
+     * Gets the annotations applied to a class.
      *
-     * @param string                                 $className
-     * @param \Doctrine\Annotations\Parser\PhpParser $phpParser
+     * @param \ReflectionFunction $function The ReflectionFunction of the function from
+     *                                      which the function annotations should be read.
+     *
+     * @return array An array of Annotations.
      */
-    public function __construct(string $className, PhpParser $phpParser)
-    {
-        parent::__construct($className);
-
-        $this->phpParser = $phpParser;
-    }
+    public function getFunctionAnnotations(ReflectionFunction $function) : array;
 
     /**
-     * @return array
+     * Gets a class annotation.
+     *
+     * @param \ReflectionFunction $function       The ReflectionFunction of the function from
+     *                                            which the given function annotation should be
+     *                                            read.
+     * @param string              $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
      */
-    public function getImports() : array
-    {
-        if ($this->imports !== null) {
-            return $this->imports;
-        }
-
-        return $this->imports = $this->phpParser->parse($this);
-    }
+    public function getFunctionAnnotation(ReflectionFunction $function, string $annotationName);
 }

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -72,7 +72,6 @@ class MetadataFactory
 
         $class       = new \ReflectionClass($className);
         $constructor = $class->getConstructor();
-        $docComment  = $class->getDocComment();
         $metadata    = new ClassMetadata();
 
         $metadata->hasConstructor = false;
@@ -83,7 +82,7 @@ class MetadataFactory
             $metadata->hasConstructor = true;
         }
 
-        $annotations = $this->parser->parseAnnotationClass($class);
+        $annotations = $this->parser->parseAnnotation($class);
         $indexed     = $this->getIndexedAnnotations($annotations);
 
         if ( ! $this->isAnnotation($class, $indexed)) {
@@ -125,8 +124,6 @@ class MetadataFactory
     /**
      * @param ReflectionClass $class
      * @param ClassMetadata   $metadata
-     *
-     * @return array
      */
     private function collectPropertiesMetadata(ReflectionClass $class, ClassMetadata $metadata)
     {

--- a/src/ObjectReader.php
+++ b/src/ObjectReader.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * Interface for object annotation readers.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ */
+interface ObjectReader
+{
+    /**
+     * Gets the annotations applied to a class.
+     *
+     * @param \ReflectionClass $class The ReflectionClass of the class from which
+     *                                the class annotations should be read.
+     *
+     * @return array An array of Annotations.
+     */
+    public function getClassAnnotations(ReflectionClass $class) : array;
+
+    /**
+     * Gets a class annotation.
+     *
+     * @param \ReflectionClass $class          The ReflectionClass of the class from which
+     *                                         the class annotations should be read.
+     * @param string           $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getClassAnnotation(ReflectionClass $class, string $annotationName);
+
+    /**
+     * Gets the annotations applied to a method.
+     *
+     * @param \ReflectionMethod $method The ReflectionMethod of the method from which
+     *                                  the annotations should be read.
+     *
+     * @return array An array of Annotations.
+     */
+    public function getMethodAnnotations(ReflectionMethod $method) : array;
+
+    /**
+     * Gets a method annotation.
+     *
+     * @param \ReflectionMethod $method         The ReflectionMethod to read the annotations from.
+     * @param string            $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getMethodAnnotation(ReflectionMethod $method, string $annotationName);
+
+    /**
+     * Gets the annotations applied to a property.
+     *
+     * @param \ReflectionProperty $property The ReflectionProperty of the property
+     *                                      from which the annotations should be read.
+     *
+     * @return array An array of Annotations.
+     */
+    public function getPropertyAnnotations(ReflectionProperty $property) : array;
+
+    /**
+     * Gets a property annotation.
+     *
+     * @param \ReflectionProperty $property       The ReflectionProperty to read the annotations from.
+     * @param string              $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getPropertyAnnotation(ReflectionProperty $property, string $annotationName);
+}

--- a/src/Parser/MetadataParser.php
+++ b/src/Parser/MetadataParser.php
@@ -23,6 +23,7 @@ namespace Doctrine\Annotations\Parser;
 
 use Reflector;
 use ReflectionClass;
+use ReflectionFunction;
 use ReflectionProperty;
 
 use Doctrine\Annotations\Context;
@@ -69,12 +70,31 @@ class MetadataParser
      * @param \ReflectionClass $class
      *
      * @return array
+     *
+     * @deprecated
      */
     public function parseAnnotationClass(ReflectionClass $class) : array
     {
-        $docblock    = $class->getDocComment();
-        $namespace   = $class->getNamespaceName();
-        $annotations = $this->parseDockblock($class, $namespace, $docblock);
+        return $this->parseAnnotation($class);
+    }
+
+    /**
+     * @param \ReflectionClass|\ReflectionFunction $reflection
+     *
+     * @return array
+     */
+    public function parseAnnotation($reflection) : array
+    {
+        if ( ! $reflection instanceof ReflectionClass && ! $reflection instanceof ReflectionFunction) {
+            throw new \InvalidArgumentException(sprintf(
+                'Reflection must be either an instance of ReflectionClass or ReflectionFunction, got %s',
+                get_class($reflection)
+            ));
+        }
+
+        $docblock    = $reflection->getDocComment();
+        $namespace   = $reflection->getNamespaceName();
+        $annotations = $this->parseDockblock($reflection, $namespace, $docblock);
 
         return $annotations;
     }
@@ -105,6 +125,8 @@ class MetadataParser
      * @param string|bool $docblock
      *
      * @return array
+     *
+     * @throws ParserException
      */
     private function parseDockblock(Reflector $reflector, $namespace, $docblock) : array
     {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -27,7 +27,7 @@ namespace Doctrine\Annotations;
  * @author     Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author     Fabio B. Silva <fabio.bat.silva@gmail.com>
  *
- * @deprecated Since version 2.0. Use Object Reader instead.
+ * @deprecated Since version 2.0. Use ObjectReader instead.
  */
 interface Reader extends ObjectReader
 {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -24,9 +24,10 @@ namespace Doctrine\Annotations;
 /**
  * Interface for annotation readers.
  *
- * @deprecated
- * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * @author     Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author     Fabio B. Silva <fabio.bat.silva@gmail.com>
+ *
+ * @deprecated Since version 2.0. Use Object Reader instead.
  */
 interface Reader extends ObjectReader
 {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -21,76 +21,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Annotations;
 
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionProperty;
-
 /**
  * Interface for annotation readers.
  *
+ * @deprecated
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
-interface Reader
+interface Reader extends ObjectReader
 {
-    /**
-     * Gets the annotations applied to a class.
-     *
-     * @param \ReflectionClass $class The ReflectionClass of the class from which
-     *                                the class annotations should be read.
-     *
-     * @return array An array of Annotations.
-     */
-    public function getClassAnnotations(ReflectionClass $class) : array;
-
-    /**
-     * Gets a class annotation.
-     *
-     * @param \ReflectionClass $class          The ReflectionClass of the class from which
-     *                                         the class annotations should be read.
-     * @param string           $annotationName The name of the annotation.
-     *
-     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
-     */
-    public function getClassAnnotation(ReflectionClass $class, string $annotationName);
-
-    /**
-     * Gets the annotations applied to a method.
-     *
-     * @param \ReflectionMethod $method The ReflectionMethod of the method from which
-     *                                  the annotations should be read.
-     *
-     * @return array An array of Annotations.
-     */
-    public function getMethodAnnotations(ReflectionMethod $method) : array;
-
-    /**
-     * Gets a method annotation.
-     *
-     * @param \ReflectionMethod $method         The ReflectionMethod to read the annotations from.
-     * @param string            $annotationName The name of the annotation.
-     *
-     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
-     */
-    public function getMethodAnnotation(ReflectionMethod $method, string $annotationName);
-
-    /**
-     * Gets the annotations applied to a property.
-     *
-     * @param \ReflectionProperty $property The ReflectionProperty of the property
-     *                                      from which the annotations should be read.
-     *
-     * @return array An array of Annotations.
-     */
-    public function getPropertyAnnotations(ReflectionProperty $property) : array;
-
-    /**
-     * Gets a property annotation.
-     *
-     * @param \ReflectionProperty $property       The ReflectionProperty to read the annotations from.
-     * @param string              $annotationName The name of the annotation.
-     *
-     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
-     */
-    public function getPropertyAnnotation(ReflectionProperty $property, string $annotationName);
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -24,11 +24,9 @@ namespace Doctrine\Annotations;
 /**
  * Interface for annotation readers.
  *
- * @author     Johannes M. Schmitt <schmittjoh@gmail.com>
- * @author     Fabio B. Silva <fabio.bat.silva@gmail.com>
- *
- * @deprecated Since version 2.0. Use ObjectReader instead.
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
-interface Reader extends ObjectReader
+interface Reader extends ObjectReader, FunctionReader
 {
 }

--- a/src/Reflection/ReflectionFactory.php
+++ b/src/Reflection/ReflectionFactory.php
@@ -46,6 +46,11 @@ class ReflectionFactory
     private $properties = [];
 
     /**
+     * @var array
+     */
+    private $functions = [];
+
+    /**
      * @var \Doctrine\Annotations\Parser\PhpParser
      */
     private $phpParser;
@@ -108,5 +113,21 @@ class ReflectionFactory
         }
 
         return $this->properties[$className . '$' . $propertyName] = new ReflectionProperty($className, $propertyName, $this->phpParser);
+    }
+
+    /**
+     * @param string $functionName The name of the function.
+     *
+     * @return \Doctrine\Annotations\Reflection\ReflectionFunction
+     *
+     * @throws \ReflectionException
+     */
+    public function getReflectionFunction(string $functionName)
+    {
+        if (isset($this->functions[$functionName])) {
+            return $this->functions[$functionName];
+        }
+
+        return $this->functions[$functionName] = new ReflectionFunction($functionName, $this->phpParser);
     }
 }

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -25,6 +25,8 @@ use Doctrine\Annotations\Parser\PhpParser;
 
 /**
  * Reflection Function
+ *
+ * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  */
 class ReflectionFunction extends \ReflectionFunction
 {

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -24,11 +24,9 @@ namespace Doctrine\Annotations\Reflection;
 use Doctrine\Annotations\Parser\PhpParser;
 
 /**
- * Reflection Property
- *
- * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
+ * Reflection Function
  */
-class ReflectionProperty extends \ReflectionProperty
+class ReflectionFunction extends \ReflectionFunction
 {
     /**
      * @var \Doctrine\Annotations\Parser\PhpParser
@@ -41,20 +39,14 @@ class ReflectionProperty extends \ReflectionProperty
     private $imports;
 
     /**
-     * @var \Doctrine\Annotations\Reflection\ReflectionClass
-     */
-    private $declaringClass;
-
-    /**
      * Constructor.
      *
-     * @param string                                 $className
-     * @param string                                 $propertyName
+     * @param string                                 $functionName
      * @param \Doctrine\Annotations\Parser\PhpParser $phpParser
      */
-    public function __construct(string $className, string $propertyName, PhpParser $phpParser)
+    public function __construct(string $functionName, PhpParser $phpParser)
     {
-        parent::__construct($className, $propertyName);
+        parent::__construct($functionName);
 
         $this->phpParser = $phpParser;
     }
@@ -68,34 +60,6 @@ class ReflectionProperty extends \ReflectionProperty
             return $this->imports;
         }
 
-        $class        = $this->getDeclaringClass();
-        $classImports = $class->getImports();
-        $traitImports = [];
-
-        foreach ($class->getTraits() as $trait) {
-            if ( ! $trait->hasProperty($this->getName())) {
-                continue;
-            }
-
-            $propertyImports = $this->phpParser->parse($trait);
-            $traitImports    = array_merge($traitImports, $propertyImports);
-        }
-
-        return $this->imports = array_merge($classImports, $traitImports);
-    }
-
-    /**
-     * @return \Doctrine\Annotations\Reflection\ReflectionClass
-     */
-    public function getDeclaringClass() : ReflectionClass
-    {
-        if ($this->declaringClass !== null) {
-            return $this->declaringClass;
-        }
-
-        $className  = parent::getDeclaringClass()->name;
-        $reflection = new ReflectionClass($className, $this->phpParser);
-
-        return $this->declaringClass = $reflection;
+        return $this->imports = $this->phpParser->parse($this);
     }
 }

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -81,7 +81,7 @@ class ReflectionMethod extends \ReflectionMethod
                 continue;
             }
 
-            $methodImports = $this->phpParser->parseClass($trait);
+            $methodImports = $this->phpParser->parse($trait);
             $traitImports  = array_merge($traitImports, $methodImports);
         }
 

--- a/tests/AbstractReaderTest.php
+++ b/tests/AbstractReaderTest.php
@@ -20,6 +20,11 @@ abstract class AbstractReaderTest extends TestCase
         return new ReflectionClass('Doctrine\AnnotationsTests\Fixtures\DummyClass');
     }
 
+    public function getReflectionFunction()
+    {
+        return new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_autoload_function');
+    }
+
     public function testAnnotations()
     {
         $class     = $this->getReflectionClass();
@@ -55,15 +60,28 @@ abstract class AbstractReaderTest extends TestCase
         $this->assertEquals('col3', $joinTableAnnot->inverseJoinColumns[0]->name);
         $this->assertEquals('col4', $joinTableAnnot->inverseJoinColumns[0]->referencedColumnName);
 
-        $dummyAnnot = $reader->getMethodAnnotation($class->getMethod('getField1'), 'Doctrine\AnnotationsTests\Fixtures\Reader\DummyAnnotation');
+        $method = $class->getMethod('getField1');
+        $dummyAnnot = $reader->getMethodAnnotation($method, 'Doctrine\AnnotationsTests\Fixtures\Reader\DummyAnnotation');
         $this->assertEquals('', $dummyAnnot->dummyValue);
         $this->assertEquals(array(1, 2, 'three'), $dummyAnnot->value);
+        $unknownAnnot = $reader->getMethodAnnotation($method, 'UnknownMethodAnnotation');
+        $this->assertNull($unknownAnnot);
 
-        $dummyAnnot = $reader->getPropertyAnnotation($class->getProperty('field1'), 'Doctrine\AnnotationsTests\Fixtures\Reader\DummyAnnotation');
+        $property = $class->getProperty('field1');
+        $dummyAnnot = $reader->getPropertyAnnotation($property, 'Doctrine\AnnotationsTests\Fixtures\Reader\DummyAnnotation');
         $this->assertEquals('fieldHello', $dummyAnnot->dummyValue);
+        $unknownAnnot = $reader->getPropertyAnnotation($property, 'UnknownPropertyAnnotation');
+        $this->assertNull($unknownAnnot);
 
         $classAnnot = $reader->getClassAnnotation($class, 'Doctrine\AnnotationsTests\Fixtures\Reader\DummyAnnotation');
         $this->assertEquals('hello', $classAnnot->dummyValue);
+        $unknownAnnot = $reader->getClassAnnotation($class, 'UnknownClassAnnotation');
+        $this->assertNull($unknownAnnot);
+
+        $function = $this->getReflectionFunction();
+        $annotations = $reader->getFunctionAnnotations($function);
+        $this->assertInstanceOf('Doctrine\AnnotationsTests\Fixtures\Annotation\Autoload', $annotations[0]);
+        $this->assertNull($reader->getFunctionAnnotation($function, 'UnknownFunctionAnnotation'));
     }
 
     public function testAnnotationsWithValidTargets()

--- a/tests/Annotation/TargetTest.php
+++ b/tests/Annotation/TargetTest.php
@@ -51,6 +51,7 @@ class TargetTest extends TestCase
             'CLASS',
             'METHOD',
             'PROPERTY',
+            'FUNCTION',
             'ANNOTATION'
         ], Target::getNames(Target::TARGET_ALL));
 
@@ -62,6 +63,11 @@ class TargetTest extends TestCase
             'METHOD',
             'PROPERTY'
         ], Target::getNames(Target::TARGET_METHOD | Target::TARGET_PROPERTY));
+
+        $this->assertEquals([
+            'CLASS',
+            'FUNCTION'
+        ], Target::getNames(Target::TARGET_FUNCTION | Target::TARGET_CLASS));
     }
 }
 

--- a/tests/AnnotationReaderTest.php
+++ b/tests/AnnotationReaderTest.php
@@ -46,4 +46,15 @@ class AnnotationReaderTest extends AbstractReaderTest
         $annotations = $reader->getPropertyAnnotations($ref->getProperty('traitProperty'));
         $this->assertInstanceOf('Doctrine\AnnotationsTests\Fixtures\Annotation\Autoload', $annotations[0]);
     }
+
+    public function testFunctionAnnotation()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_autoload_function');
+
+        $annotations = $reader->getFunctionAnnotations($ref);
+        $this->assertInstanceOf('Doctrine\AnnotationsTests\Fixtures\Annotation\Autoload', $annotations[0]);
+
+        $this->assertNull($reader->getFunctionAnnotation($ref, 'foo'));
+    }
 }

--- a/tests/AnnotationReaderTest.php
+++ b/tests/AnnotationReaderTest.php
@@ -46,15 +46,4 @@ class AnnotationReaderTest extends AbstractReaderTest
         $annotations = $reader->getPropertyAnnotations($ref->getProperty('traitProperty'));
         $this->assertInstanceOf('Doctrine\AnnotationsTests\Fixtures\Annotation\Autoload', $annotations[0]);
     }
-
-    public function testFunctionAnnotation()
-    {
-        $reader = $this->getReader();
-        $ref = new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_autoload_function');
-
-        $annotations = $reader->getFunctionAnnotations($ref);
-        $this->assertInstanceOf('Doctrine\AnnotationsTests\Fixtures\Annotation\Autoload', $annotations[0]);
-
-        $this->assertNull($reader->getFunctionAnnotation($ref, 'foo'));
-    }
 }

--- a/tests/CachedReaderTest.php
+++ b/tests/CachedReaderTest.php
@@ -14,11 +14,8 @@ class CachedReaderTest extends AbstractReaderTest
      */
     public function testInvalidReaderClass()
     {
-        $namespaces   = ['Doctrine\AnnotationsTests\Fixtures'];
         $cache  = $this->getMockBuilder('Doctrine\Common\Cache\Cache')->getMock();
-        $class = new CachedReader(new InvalidReader(), $cache, true);
-
-        new Context($class, $namespaces);
+        new CachedReader(new InvalidReader(), $cache, true);
     }
 
     public function testIgnoresStaleCache()

--- a/tests/CachedReaderTest.php
+++ b/tests/CachedReaderTest.php
@@ -4,10 +4,23 @@ namespace Doctrine\AnnotationsTests;
 
 use Doctrine\Annotations\AnnotationReader;
 use Doctrine\Annotations\CachedReader;
+use Doctrine\AnnotationsTests\Fixtures\InvalidReader;
 use Doctrine\Common\Cache\ArrayCache;
 
 class CachedReaderTest extends AbstractReaderTest
 {
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidReaderClass()
+    {
+        $namespaces   = ['Doctrine\AnnotationsTests\Fixtures'];
+        $cache  = $this->getMockBuilder('Doctrine\Common\Cache\Cache')->getMock();
+        $class = new CachedReader(new InvalidReader(), $cache, true);
+
+        new Context($class, $namespaces);
+    }
+
     public function testIgnoresStaleCache()
     {
         $name     = 'Doctrine\AnnotationsTests\Fixtures\Controller';

--- a/tests/CachedReaderTest.php
+++ b/tests/CachedReaderTest.php
@@ -4,20 +4,10 @@ namespace Doctrine\AnnotationsTests;
 
 use Doctrine\Annotations\AnnotationReader;
 use Doctrine\Annotations\CachedReader;
-use Doctrine\AnnotationsTests\Fixtures\InvalidReader;
 use Doctrine\Common\Cache\ArrayCache;
 
 class CachedReaderTest extends AbstractReaderTest
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidReaderClass()
-    {
-        $cache  = $this->getMockBuilder('Doctrine\Common\Cache\Cache')->getMock();
-        new CachedReader(new InvalidReader(), $cache, true);
-    }
-
     public function testIgnoresStaleCache()
     {
         $name     = 'Doctrine\AnnotationsTests\Fixtures\Controller';

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -29,17 +29,20 @@ class ContextTest extends TestCase
 
     public function testContextDescription()
     {
-        $namespaces   = ['Doctrine\AnnotationsTests\Fixtures'];
-        $class        = new \ReflectionClass('Doctrine\AnnotationsTests\Fixtures\Controller');
-        $property     = new \ReflectionProperty('Doctrine\AnnotationsTests\Fixtures\Controller', 'service');
-        $method       = new \ReflectionMethod('Doctrine\AnnotationsTests\Fixtures\Controller', 'indexAction');
+        $namespaces = ['Doctrine\AnnotationsTests\Fixtures'];
+        $class      = new \ReflectionClass('Doctrine\AnnotationsTests\Fixtures\Controller');
+        $property   = new \ReflectionProperty('Doctrine\AnnotationsTests\Fixtures\Controller', 'service');
+        $method     = new \ReflectionMethod('Doctrine\AnnotationsTests\Fixtures\Controller', 'indexAction');
+        $function   = new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function');
 
         $classContext    = new Context($class, $namespaces);
         $methodsContext  = new Context($method, $namespaces);
         $propertyContext = new Context($property, $namespaces);
+        $functionContext = new Context($function, $namespaces);
 
         $this->assertEquals('class Doctrine\AnnotationsTests\Fixtures\Controller', $classContext->getDescription());
         $this->assertEquals('property Doctrine\AnnotationsTests\Fixtures\Controller::$service', $propertyContext->getDescription());
         $this->assertEquals('method Doctrine\AnnotationsTests\Fixtures\Controller::indexAction()', $methodsContext->getDescription());
+        $this->assertEquals('function Doctrine\AnnotationsTests\Fixtures\dummy_function', $functionContext->getDescription());
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\AnnotationsTests;
 
+use Doctrine\Annotations\Annotation\Target;
 use Doctrine\Annotations\Context;
+use Doctrine\AnnotationsTests\Fixtures\DummyClass;
 
 class ContextTest extends TestCase
 {
@@ -27,13 +29,32 @@ class ContextTest extends TestCase
         $this->assertFalse($context->isIgnoredName('Foo'));
     }
 
+    public function testContextTarget()
+    {
+        $namespaces = ['Doctrine\AnnotationsTests\Fixtures'];
+        $class      = new \ReflectionClass('Doctrine\AnnotationsTests\Fixtures\Controller');
+        $property   = new \ReflectionProperty('Doctrine\AnnotationsTests\Fixtures\Controller', 'service');
+        $method     = new \ReflectionMethod('Doctrine\AnnotationsTests\Fixtures\Controller', 'indexAction');
+        $function   = new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_enum_function');
+
+        $classContext    = new Context($class, $namespaces);
+        $methodsContext  = new Context($method, $namespaces);
+        $propertyContext = new Context($property, $namespaces);
+        $functionContext = new Context($function, $namespaces);
+
+        $this->assertEquals(Target::TARGET_CLASS, $classContext->getTarget());
+        $this->assertEquals(Target::TARGET_PROPERTY, $propertyContext->getTarget());
+        $this->assertEquals(Target::TARGET_METHOD, $methodsContext->getTarget());
+        $this->assertEquals(Target::TARGET_FUNCTION, $functionContext->getTarget());
+    }
+
     public function testContextDescription()
     {
         $namespaces = ['Doctrine\AnnotationsTests\Fixtures'];
         $class      = new \ReflectionClass('Doctrine\AnnotationsTests\Fixtures\Controller');
         $property   = new \ReflectionProperty('Doctrine\AnnotationsTests\Fixtures\Controller', 'service');
         $method     = new \ReflectionMethod('Doctrine\AnnotationsTests\Fixtures\Controller', 'indexAction');
-        $function   = new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function');
+        $function   = new \ReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_enum_function');
 
         $classContext    = new Context($class, $namespaces);
         $methodsContext  = new Context($method, $namespaces);
@@ -43,6 +64,6 @@ class ContextTest extends TestCase
         $this->assertEquals('class Doctrine\AnnotationsTests\Fixtures\Controller', $classContext->getDescription());
         $this->assertEquals('property Doctrine\AnnotationsTests\Fixtures\Controller::$service', $propertyContext->getDescription());
         $this->assertEquals('method Doctrine\AnnotationsTests\Fixtures\Controller::indexAction()', $methodsContext->getDescription());
-        $this->assertEquals('function Doctrine\AnnotationsTests\Fixtures\dummy_function', $functionContext->getDescription());
+        $this->assertEquals('function Doctrine\AnnotationsTests\Fixtures\annotation_enum_function', $functionContext->getDescription());
     }
 }

--- a/tests/Fixtures/InvalidReader.php
+++ b/tests/Fixtures/InvalidReader.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Doctrine\AnnotationsTests\Fixtures;
-
-class InvalidReader
-{
-
-}

--- a/tests/Fixtures/InvalidReader.php
+++ b/tests/Fixtures/InvalidReader.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\AnnotationsTests\Fixtures;
+
+class InvalidReader
+{
+
+}

--- a/tests/Fixtures/functions.php
+++ b/tests/Fixtures/functions.php
@@ -3,11 +3,18 @@
 namespace Doctrine\AnnotationsTests\Fixtures;
 
 use Doctrine\AnnotationsTests\Fixtures\Annotation\AnnotationEnum;
+use Doctrine\AnnotationsTests\Fixtures\Annotation\Autoload;
 
 /**
  * @AnnotationEnum(AnnotationEnum::ONE)
  */
-function dummy_function()
+function annotation_enum_function()
 {
+}
 
+/**
+ * @Autoload
+ */
+function annotation_autoload_function()
+{
 }

--- a/tests/Fixtures/functions.php
+++ b/tests/Fixtures/functions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\AnnotationsTests\Fixtures;
+
+use Doctrine\AnnotationsTests\Fixtures\Annotation\AnnotationEnum;
+
+/**
+ * @AnnotationEnum(AnnotationEnum::ONE)
+ */
+function dummy_function()
+{
+
+}

--- a/tests/Parser/DocParserTest.php
+++ b/tests/Parser/DocParserTest.php
@@ -715,7 +715,7 @@ DOCBLOCK;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid Target "Foo". Available targets: [ALL, CLASS, METHOD, PROPERTY, ANNOTATION]
+     * @expectedExceptionMessage Invalid Target "Foo". Available targets: [ALL, CLASS, METHOD, PROPERTY, FUNCTION, ANNOTATION]
      */
     public function testAnnotationWithInvalidTargetDeclarationError()
     {

--- a/tests/Parser/MetadataParserTest.php
+++ b/tests/Parser/MetadataParserTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\AnnotationsTests\Metadata;
+
+use Doctrine\AnnotationsTests\Fixtures\DummyClass;
+use Doctrine\AnnotationsTests\TestCase;
+
+use Doctrine\Annotations\Parser\MetadataParser;
+use Doctrine\Annotations\Parser\HoaParser;
+use Doctrine\Annotations\Resolver;
+
+class MetadataParserTest extends TestCase
+{
+    /**
+     * @return \Doctrine\Annotations\Parser\MetadataParser
+     */
+    public function createMetadataParser() : MetadataParser
+    {
+        $resolver  = new Resolver();
+        $hoaParser = new HoaParser();
+
+        return new MetadataParser($hoaParser, $resolver);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidReflectionClass()
+    {
+        $factory = $this->createMetadataParser();
+
+        $factory->parseAnnotation(new DummyClass());
+}
+}

--- a/tests/Parser/PhpParserTest.php
+++ b/tests/Parser/PhpParserTest.php
@@ -2,7 +2,10 @@
 
 namespace Doctrine\AnnotationsTests\Parser;
 
+
 use ReflectionClass;
+
+use Doctrine\AnnotationsTests\Fixtures\DummyClass;
 use Doctrine\Annotations\Parser\PhpParser;
 
 require_once __DIR__ . '/../Fixtures/NonNamespacedClass.php';
@@ -11,7 +14,18 @@ require_once __DIR__ . '/../Fixtures/GlobalNamespacesPerFileWithClassAsLast.php'
 
 class PhpParserTest extends \PHPUnit_Framework_TestCase
 {
-    public function testParseClassWithMultipleClassesInFile()
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidReflectionClass()
+    {
+        $class = new DummyClass();
+        $parser = new PhpParser();
+
+        $parser->parse($class);
+    }
+
+    public function testParseWithMultipleClassesInFile()
     {
         $class = new ReflectionClass('Doctrine\AnnotationsTests\Fixtures\MultipleClassesInFile');
         $parser = new PhpParser();
@@ -19,10 +33,10 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'route'  => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'secure' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
-    public function testParseClassWithMultipleImportsInUseStatement()
+    public function testParseWithMultipleImportsInUseStatement()
     {
         $class = new ReflectionClass('Doctrine\AnnotationsTests\Fixtures\MultipleImportsInUseStatement');
         $parser = new PhpParser();
@@ -30,13 +44,13 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'route'  => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'secure' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
-    public function testParseClassWhenNotUserDefined()
+    public function testParseWhenNotUserDefined()
     {
         $parser = new PhpParser();
-        $this->assertEquals(array(), $parser->parseClass(new \ReflectionClass('\stdClass')));
+        $this->assertEquals(array(), $parser->parse(new \ReflectionClass('\stdClass')));
     }
 
     public function testClassFileDoesNotExist()
@@ -54,12 +68,12 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
             ->willReturn(10);
 
         $parser = new PhpParser();
-        $result = $parser->parseClass($class);
+        $result = $parser->parse($class);
 
         $this->assertEquals([], $result);
     }
 
-    public function testParseClassWhenClassIsNotNamespaced()
+    public function testParseWhenClassIsNotNamespaced()
     {
         $parser = new PhpParser();
         $class = new ReflectionClass('\AnnotationsTestsFixturesNonNamespacedClass');
@@ -67,17 +81,17 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
-    public function testParseClassWhenClassIsInterface()
+    public function testParseWhenClassIsInterface()
     {
         $parser = new PhpParser();
         $class = new ReflectionClass('Doctrine\AnnotationsTests\Fixtures\TestInterface');
 
         $this->assertEquals(array(
             'secure' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testClassWithFullyQualifiedUseStatements()
@@ -89,7 +103,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
             'secure'   => '\Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
             'route'    => '\Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => '\Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testNamespaceAndClassCommentedOut()
@@ -100,7 +114,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
 	}
 
     public function testEqualNamespacesPerFileWithClassAsFirst()
@@ -111,7 +125,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'secure'   => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testEqualNamespacesPerFileWithClassAsLast()
@@ -122,7 +136,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testDifferentNamespacesPerFileWithClassAsFirst()
@@ -132,7 +146,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(
             'secure'   => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testDifferentNamespacesPerFileWithClassAsLast()
@@ -142,7 +156,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testGlobalNamespacesPerFileWithClassAsFirst()
@@ -153,7 +167,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'secure'   => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testGlobalNamespacesPerFileWithClassAsLast()
@@ -164,7 +178,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testNamespaceWithClosureDeclaration()
@@ -176,7 +190,7 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
             'secure'   => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     public function testIfPointerResetsOnMultipleParsingTries()
@@ -188,13 +202,13 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
             'secure'   => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
 
         $this->assertEquals(array(
             'secure'   => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Secure',
             'route'    => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Route',
             'template' => 'Doctrine\AnnotationsTests\Fixtures\Annotation\Template',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 
     /**
@@ -209,6 +223,6 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
           'annotationtargetall'         => 'Doctrine\AnnotationsTests\Fixtures\AnnotationTargetAll',
           'annotationtargetannotation'  => 'Doctrine\AnnotationsTests\Fixtures\AnnotationTargetAnnotation',
-        ), $parser->parseClass($class));
+        ), $parser->parse($class));
     }
 }

--- a/tests/Reflection/ReflectionFactoryTest.php
+++ b/tests/Reflection/ReflectionFactoryTest.php
@@ -61,11 +61,11 @@ class ReflectionFactoryTest extends TestCase
     public function testGetReflectionFunction()
     {
         $factory    = $this->createReflectionFactory();
-        $reflection = $factory->getReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function');
+        $reflection = $factory->getReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_enum_function');
 
         $this->assertInstanceOf('\ReflectionFunction', $reflection);
         $this->assertInstanceOf(ReflectionFunction::CLASS, $reflection);
 
-        $this->assertSame($reflection, $factory->getReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function'));
+        $this->assertSame($reflection, $factory->getReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_enum_function'));
     }
 }

--- a/tests/Reflection/ReflectionFactoryTest.php
+++ b/tests/Reflection/ReflectionFactoryTest.php
@@ -7,6 +7,7 @@ use Doctrine\AnnotationsTests\Fixtures\ClassWithAnnotationEnum;
 
 use Doctrine\Annotations\Parser\PhpParser;
 use Doctrine\Annotations\Reflection\ReflectionClass;
+use Doctrine\Annotations\Reflection\ReflectionFunction;
 use Doctrine\Annotations\Reflection\ReflectionMethod;
 use Doctrine\Annotations\Reflection\ReflectionProperty;
 use Doctrine\Annotations\Reflection\ReflectionFactory;
@@ -55,5 +56,16 @@ class ReflectionFactoryTest extends TestCase
         $this->assertInstanceOf(ReflectionProperty::CLASS, $reflection);
 
         $this->assertSame($reflection, $factory->getReflectionProperty(ClassWithAnnotationEnum::CLASS, 'foo'));
+    }
+
+    public function testGetReflectionFunction()
+    {
+        $factory    = $this->createReflectionFactory();
+        $reflection = $factory->getReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function');
+
+        $this->assertInstanceOf('\ReflectionFunction', $reflection);
+        $this->assertInstanceOf(ReflectionFunction::CLASS, $reflection);
+
+        $this->assertSame($reflection, $factory->getReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function'));
     }
 }

--- a/tests/Reflection/ReflectionFunctionTest.php
+++ b/tests/Reflection/ReflectionFunctionTest.php
@@ -26,7 +26,7 @@ class ReflectionFunctionTest extends TestCase
 
     public function testGetImports()
     {
-        $reflection = $this->createReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function');
+        $reflection = $this->createReflectionFunction('Doctrine\AnnotationsTests\Fixtures\annotation_enum_function');
         $imports    = $reflection->getImports();
 
         $this->assertArrayHasKey('annotationenum', $imports);

--- a/tests/Reflection/ReflectionFunctionTest.php
+++ b/tests/Reflection/ReflectionFunctionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\AnnotationsTests\Reflection;
+
+use Doctrine\Annotations\Reflection\ReflectionFunction;
+use Doctrine\AnnotationsTests\TestCase;
+use Doctrine\AnnotationsTests\Fixtures\ClassWithAnnotationEnum;
+use Doctrine\AnnotationsTests\Fixtures\Annotation\AnnotationEnum;
+
+use Doctrine\Annotations\Parser\PhpParser;
+
+class ReflectionFunctionTest extends TestCase
+{
+    /**
+     * @param string $function
+     *
+     * @return \Doctrine\Annotations\Reflection\ReflectionFunction
+     */
+    public function createReflectionFunction(string $function) : ReflectionFunction
+    {
+        $parser     = new PhpParser();
+        $reflection = new ReflectionFunction($function, $parser);
+
+        return $reflection;
+    }
+
+    public function testGetImports()
+    {
+        $reflection = $this->createReflectionFunction('Doctrine\AnnotationsTests\Fixtures\dummy_function');
+        $imports    = $reflection->getImports();
+
+        $this->assertArrayHasKey('annotationenum', $imports);
+        $this->assertEquals(AnnotationEnum::CLASS, $imports['annotationenum']);
+        $this->assertEquals($imports, $reflection->getImports());
+    }
+}


### PR DESCRIPTION
I know, this is maybe a strange way to add this functionality, but as this changes should be on top of https://github.com/doctrine/annotations/pull/75 I think it's best to make this PR agains this forked repository to be able to focus on the right changes.

Mind that this is also a very big *WIP* in the title, as I really need to see what are the Do's and Dont's in the doctrine family. I'm really happy to hear, what you think and open to every kind of feedback.

Fixes: https://github.com/doctrine/annotations/issues/83#issuecomment-272241773

* [x] Read annotations also from functions
* [x] Write additional tests
* [ ] Gather feedback